### PR TITLE
Adds optional security context to all pods

### DIFF
--- a/manifests/cart-redis-total.yaml
+++ b/manifests/cart-redis-total.yaml
@@ -34,6 +34,7 @@ spec:
         app: acmefit  # has to match .spec.selector.matchLabels
         service: cart-redis
     spec:
+      securityContext: repl{{ ternary (ConfigOption "pod_security_context" ) "{}" (ConfigOptionEquals "enable_pod_security" "1" ) | nindent 8 }}
       containers:
         - name: cart-redis
           image: bitnami/redis

--- a/manifests/cart-total.yaml
+++ b/manifests/cart-total.yaml
@@ -35,6 +35,7 @@ spec:
         app: acmefit
         service: cart
     spec:
+      securityContext: repl{{ ternary (ConfigOption "pod_security_context" ) "{}" (ConfigOptionEquals "enable_pod_security" "1" ) | nindent 8 }}
       volumes:
       - name: acmefit-cart-data
         emptyDir: {}

--- a/manifests/catalog-db-total.yaml
+++ b/manifests/catalog-db-total.yaml
@@ -34,6 +34,7 @@ spec:
         app: acmefit  # has to match .spec.selector.matchLabels
         service: catalog-db
     spec:
+      securityContext: repl{{ ternary (ConfigOption "pod_security_context" ) "{}" (ConfigOptionEquals "enable_pod_security" "1" ) | nindent 8 }}
       containers:
         - name: catalog-mongo
           image: mongo:4

--- a/manifests/catalog-total.yaml
+++ b/manifests/catalog-total.yaml
@@ -35,6 +35,7 @@ spec:
         app: acmefit
         service: catalog
     spec:
+      securityContext: repl{{ ternary (ConfigOption "pod_security_context" ) "{}" (ConfigOptionEquals "enable_pod_security" "1" ) | nindent 8 }}
       volumes:
       - name: acmefit-catalog-data
         emptyDir: {}

--- a/manifests/frontend-total.yaml
+++ b/manifests/frontend-total.yaml
@@ -38,6 +38,7 @@ spec:
         app: acmefit
         service: frontend
     spec:
+      securityContext: repl{{ ternary (ConfigOption "pod_security_context" ) "{}" (ConfigOptionEquals "enable_pod_security" "1" ) | nindent 8 }}
       containers:
       - image: registry.shortrib.dev/acme-fitness/acmeshop-front-end:latest
         name: frontend

--- a/manifests/kots-config.yaml
+++ b/manifests/kots-config.yaml
@@ -15,6 +15,19 @@ spec:
       type: text
       required: true
       default: "acme-fitness.local"
+  - name: security
+    title: Security
+    description: Optional security features
+    items:
+    - name: enable_pod_security
+      type: bool
+      title: Enable Pod Security
+      default: "0"
+    - name: pod_security_context
+      title: Pod Security Context
+      help_text: "Pod security context"
+      type: textarea
+      when: '{{repl ConfigOptionEquals "enable_pod_security" "1"}}'
   - name: tls
     title: TLS
     description: Configures TLS for the exposed services

--- a/manifests/order-db-total.yaml
+++ b/manifests/order-db-total.yaml
@@ -39,6 +39,7 @@ spec:
         app: acmefit
         service: order-db
     spec:
+      securityContext: repl{{ ternary (ConfigOption "pod_security_context" ) "{}" (ConfigOptionEquals "enable_pod_security" "1" ) | nindent 8 }}
       containers:
       - name: postgres
         image: postgres:9.5

--- a/manifests/order-total.yaml
+++ b/manifests/order-total.yaml
@@ -35,6 +35,7 @@ spec:
         app: acmefit
         service: order
     spec:
+      securityContext: repl{{ ternary (ConfigOption "pod_security_context" ) "{}" (ConfigOptionEquals "enable_pod_security" "1" ) | nindent 8 }}
       volumes:
       - name: acmefit-order-data
         emptyDir: {}

--- a/manifests/payment-total.yaml
+++ b/manifests/payment-total.yaml
@@ -35,6 +35,7 @@ spec:
         app: acmefit
         service: payment
     spec:
+      securityContext: repl{{ ternary (ConfigOption "pod_security_context" ) "{}" (ConfigOptionEquals "enable_pod_security" "1" ) | nindent 8 }}
       containers:
       - image: registry.shortrib.dev/acme-fitness/acmeshop-payment:latest
         name: payment

--- a/manifests/point-of-sales-total.yaml
+++ b/manifests/point-of-sales-total.yaml
@@ -37,6 +37,7 @@ spec:
         app: acmefit
         service: pos
     spec:
+      securityContext: repl{{ ternary (ConfigOption "pod_security_context" ) "{}" (ConfigOptionEquals "enable_pod_security" "1" ) | nindent 8 }}
       containers:
       - image: gcr.io/vmwarecloudadvocacy/acmeshop-pos:v0.1.0-beta
         name: pos

--- a/manifests/users-db-total.yaml
+++ b/manifests/users-db-total.yaml
@@ -34,6 +34,7 @@ spec:
         app: acmefit  # has to match .spec.selector.matchLabels
         service: users-mongo
     spec:
+      securityContext: repl{{ ternary (ConfigOption "pod_security_context" ) "{}" (ConfigOptionEquals "enable_pod_security" "1" ) | nindent 8 }}
       containers:
         - name: users-mongo
           image: mongo:4

--- a/manifests/users-redis-total.yaml
+++ b/manifests/users-redis-total.yaml
@@ -32,6 +32,7 @@ spec:
         app: acmefit  # has to match .spec.selector.matchLabels
         service: users-redis
     spec:
+      securityContext: repl{{ ternary (ConfigOption "pod_security_context" ) "{}" (ConfigOptionEquals "enable_pod_security" "1" ) | nindent 8 }}
       containers:
         - name: users-redis
           image: bitnami/redis

--- a/manifests/users-total.yaml
+++ b/manifests/users-total.yaml
@@ -35,6 +35,7 @@ spec:
         app: acmefit
         service: users
     spec:
+      securityContext: repl{{ ternary (ConfigOption "pod_security_context" ) "{}" (ConfigOptionEquals "enable_pod_security" "1" ) | nindent 8 }}
       volumes:
       - name: acmefit-users-data
         emptyDir: {}


### PR DESCRIPTION
TL;DR
-----

Provides customers the option to specify a security context for all pods

Details
-------

Allows the customer the option to enable and specify the pod security
context for all application pods within the Replicated config.
